### PR TITLE
Add Docker core files

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,12 @@
+### WEB ######################
+WEB_PORT=80
+
+### APP ######################
+APP_SSH_PORT=2222
+
+### DB #######################
+DB_USERNAME=homestead
+DB_DATABASE=homestead
+DB_PASSWORD=secret
+DB_ROOT_PASSWORD=secret
+DB_PORT=3306

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ src/Homestead.yaml
 src/npm-debug.log
 src/yarn-error.log
 .vscode
+src/log

--- a/Docker/raspiMonitor/Dockerfile
+++ b/Docker/raspiMonitor/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:7.3.7-fpm-buster
 
-RUN apt-get update
-RUN apt-get install iproute2 nodejs npm openssh-server -y
+RUN apt-get update && \
+apt-get install iproute2 nodejs npm openssh-server -y
 
 WORKDIR /tmp
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"

--- a/Docker/raspiMonitor/Dockerfile
+++ b/Docker/raspiMonitor/Dockerfile
@@ -1,0 +1,20 @@
+FROM php:7.3.7-fpm-buster
+
+RUN apt-get update
+RUN apt-get install iproute2 nodejs npm openssh-server -y
+
+WORKDIR /tmp
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+RUN php -r "if (hash_file('sha384', 'composer-setup.php') === 'a5c698ffe4b8e849a443b120cd5ba38043260d5c4023dbf93e1558871f1f07f58274fc6f4c93bcfd858c6bd0775cd8d1') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
+RUN php composer-setup.php
+RUN php -r "unlink('composer-setup.php');"
+RUN mv composer.phar /usr/local/bin/composer
+
+COPY src/ /var/www/RaspiMonitor/
+
+WORKDIR /var/www/RaspiMonitor
+RUN composer install
+RUN npm install
+
+RUN docker-php-ext-install pdo_mysql
+RUN pecl install xdebug

--- a/Docker/web/default.conf
+++ b/Docker/web/default.conf
@@ -1,0 +1,35 @@
+server {
+
+    listen 80;
+    server_name localhost;
+    root /var/www/RaspiMonitor/public;
+
+    add_header X-Frame-Options "SAMEORIGIN";
+    add_header X-XSS-Protection "1; mode=block";
+    add_header X-Content-Type-Options "nosniff";
+
+    index index.html index.htm index.php;
+
+    charset utf-8;
+
+    location / {
+        try_files $uri $uri/ /index.php?$query_string;
+    }
+
+    location = /favicon.ico { access_log off; log_not_found off; }
+    location = /robots.txt  { access_log off; log_not_found off; }
+
+    error_page 404 /index.php;
+
+    location ~ \.php$ {
+        fastcgi_pass app:9000;
+        fastcgi_index index.php;
+        fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+        include fastcgi_params;
+    }
+
+    location ~ /\.(?!well-known).* {
+        deny all;
+    }
+
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+version: "3"
+services:
+    web:
+        image: nginx:1.14.2-alpine
+        container_name: "raspiMonitor_web"
+        ports:
+            - "${WEB_PORT}:80"
+        depends_on:
+            - app
+        volumes:
+            - ./Docker/web/default.conf:/etc/nginx/conf.d/default.conf
+            - ./src:/var/www/RaspiMonitor
+
+    app:
+        build: 
+            context: ./
+            dockerfile: ./Docker/raspiMonitor/Dockerfile
+        container_name: "raspiMonitor_app"
+        ports:
+            - "${APP_SSH_PORT}:22"
+        depends_on:
+            - db
+        volumes:
+            - ./src:/var/www/RaspiMonitor
+
+    db:
+        image: mariadb:10.3.15
+        container_name: "raspiMonitor_db"
+        restart: always
+        environment:
+            MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
+            MYSQL_USER: ${DB_USERNAME}
+            MYSQL_PASSWORD: ${DB_PASSWORD}
+            MYSQL_DATABASE: ${DB_DATABASE}
+            TZ: "Asia/Tokyo"
+        ports:
+            - ${DB_PORT}:3306


### PR DESCRIPTION
I add Dockerfile, docker-compose.yml
You can develop RaspiMonitor on Docker environment by this PR.

The .env file define exposed ports of docker containers.
If you are already using 80, 2222 and 3306 ports, you must edit .env file.
You exec "docker-compose up -d", develop environment is built.
