### PR TITLE
#5 Fix CPU info card on Docker env.

### DIFF
--- a/src/.env.example
+++ b/src/.env.example
@@ -6,6 +6,8 @@ APP_URL=http://localhost
 
 LOG_CHANNEL=stack
 
+ENV_DOCKER=true
+
 DB_CONNECTION=mysql
 DB_HOST=127.0.0.1
 DB_PORT=3306

--- a/src/app/Http/Controllers/HomeController.php
+++ b/src/app/Http/Controllers/HomeController.php
@@ -113,7 +113,7 @@ class HomeController extends Controller
             return null;
         }
 
-        if (config('app.debug', false) === false) {
+        if (config('env.docker', false) === false) {
             exec("cat /sys/class/thermal/thermal_zone0/temp", $cpuTempRawData, $isFailed);
             if (!$isFailed) {
                 $cpuInfo["temp"] = round($cpuTempRawData[0] / 1000);

--- a/src/config/env.php
+++ b/src/config/env.php
@@ -1,0 +1,7 @@
+<?php
+
+return array(
+
+	'docker' => env('ENV_DOCKER', false),
+
+);

--- a/src/resources/views/layouts/cpu.blade.php
+++ b/src/resources/views/layouts/cpu.blade.php
@@ -2,10 +2,10 @@
     <div class="card" style="width: 18rem;">
         <div class="card-body">
             <h5 class="card-title">CPU</h5>
-            <h6 class="card-subtitle mb-2 text-muted">{{ $cpuInfo["modelName"] }}</h6>
+            <h6 class="card-subtitle mb-2 text-muted">{{ @$cpuInfo["modelName"] }}</h6>
             <p class="card-text">
-            Core(s): {{ $cpuInfo["cores"] }}<br>
-            Temp: {{ $cpuInfo["temp"] }}℃<br>
+            Core(s): {{ @$cpuInfo["cores"] }}<br>
+            Temp: {{ @$cpuInfo["temp"] }}℃<br>
             {{-- Clock:  --}}
             </p>
         </div>


### PR DESCRIPTION
Fix CPU info card on Docker env.
<img width="355" alt="スクリーンショット 2019-09-08 17 47 47" src="https://user-images.githubusercontent.com/22887835/64485887-d09aa580-d260-11e9-83ab-d866c9f70b9c.png">
CPU temp is pseudo value, because can not get cpu temp on Docker containers.